### PR TITLE
fix(docker): save 589.5MB by fixing .dockerignore

### DIFF
--- a/.docker/.dockerignore
+++ b/.docker/.dockerignore
@@ -1,3 +1,8 @@
 node_modules
 config
 .next
+**/.git
+**/.gitignore
+**/.gitmodules
+**/.golangci.yml
+**/.github

--- a/.docker/prepare.sh
+++ b/.docker/prepare.sh
@@ -13,3 +13,4 @@ cd ..
 
 # Move the files to the root of the project
 mv seanime/* .
+cp .docker/.dockerignore .


### PR DESCRIPTION
This PR fixes a build context issue where the entire `.git` history and development configs were being copied into the final Docker image, causing massive unnecessary bloat.

### Changes

* **Updated `.dockerignore`**: Added exclusions for `.git`, `.gitignore`, `.gitmodules`, `.golangci.yml`, and `.github` directories.
* **Updated `prepare.sh`**: Added a step to copy `.docker/.dockerignore` to the build root so Docker correctly respects these exclusions during the build.

### Impact

* **Image Size:** Reduced by **~589.5 MB**.

*Verified locally: The final image binary and functionality remain unchanged, but the `.git` directory and other bloat are no longer present in `/app`.*

<img width="1273" height="689" alt="image" src="https://github.com/user-attachments/assets/6de1df2f-c71b-4e96-8886-3d5290d12e4c" />