### PR TITLE
docs: document custom UID/GID support via Docker native user flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,57 @@ Check the [examples](./examples) directory for complete configurations:
 - `/anime` - Media library (mount your anime directory here).
 - `/downloads` - Downloads directory.
 
+## Custom User/Group ID
+
+The rootless, hwaccel, and CUDA variants run as a non-root user with a
+default UID:GID (1000:1000 for rootless/hwaccel, 1001:1001 for CUDA). If your
+media library uses different ownership, you can override this using Docker's
+native `user` option — no rebuild required.
+
+> Unlike LinuxServer.io images, seanime uses Docker's built-in `user:` flag
+> rather than PUID/PGID environment variables. Same result, no extra overhead.
+
+### Docker Compose
+
+```yaml
+services:
+  seanime:
+    image: umagistr/seanime:latest-rootless
+    user: "1000:1500"  # <-- your UID:GID here
+    volumes:
+      - ./seanime-config:/home/seanime/.config/Seanime
+      - ./anime:/anime
+      - ./downloads:/downloads
+    ports:
+      - 3211:43211
+```
+
+### Docker Run
+
+```bash
+docker run -d \
+  --name seanime \
+  --user 1000:1500 \
+  -p 3211:43211 \
+  -v ./seanime-config:/home/seanime/.config/Seanime \
+  -v ./anime:/anime \
+  -v ./downloads:/downloads \
+  umagistr/seanime:latest-rootless
+```
+
+### Important Notes
+
+- **Pre-chown volumes** to match your chosen UID:GID:
+  ```bash
+  sudo chown -R 1000:1500 ./seanime-config
+  ```
+- **Config path** remains `/home/seanime/.config/Seanime` regardless of the
+  UID you set — this is baked into the image.
+- Works with all non-root variants: `latest-rootless`, `latest-hwaccel`, and
+  `latest-cuda`.
+- The **default** (root) variant already runs as root, so `user:` is not
+  typically needed.
+
 ## Hardware Acceleration
 
 ### Intel QSV/VAAPI

--- a/examples/02-rootless/README.md
+++ b/examples/02-rootless/README.md
@@ -19,6 +19,21 @@ This setup runs Seanime as a non-root user (UID 1000) for improved security.
 - **User**: Runs as `seanime` (UID 1000) inside the container.
 - **Image**: `umagistr/seanime:latest-rootless`
 
+## Custom UID/GID
+
+If your media library uses different ownership (e.g. 1000:1500), set the
+`user` field in docker-compose.yml:
+
+```yaml
+user: "1000:1500"
+```
+
+Then chown your volumes to match:
+
+```bash
+sudo chown -R 1000:1500 ./seanime-config
+```
+
 ## Important
 
 If migrating from the default root-based image, you must update your volume

--- a/examples/02-rootless/docker-compose.yml
+++ b/examples/02-rootless/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   seanime:
     image: umagistr/seanime:latest-rootless
     container_name: seanime
+    # user: "1000:1500"  # Optional: override UID:GID (default is 1000:1000)
     ports:
       - "3211:43211"
     volumes:

--- a/examples/03-hwaccel/README.md
+++ b/examples/03-hwaccel/README.md
@@ -34,6 +34,24 @@ uses the rootless variant as a base.
 - **Groups**: Container user added to host `video` and `render` groups for GPU
   access.
 
+## Custom UID/GID
+
+If your media library uses different ownership, set the `user` field in
+docker-compose.yml:
+
+```yaml
+user: "1000:1500"
+```
+
+Then chown your volumes to match:
+
+```bash
+sudo chown -R 1000:1500 ./seanime-config
+```
+
+The `group_add` directive for `video` and `render` continues to work alongside
+`user:` — it uses host group IDs which are unaffected by the UID:GID override.
+
 ## Important
 
 - This variant is **amd64 only** for hardware acceleration features.

--- a/examples/03-hwaccel/docker-compose.yml
+++ b/examples/03-hwaccel/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   seanime:
     image: umagistr/seanime:latest-hwaccel
     container_name: seanime
+    # user: "1000:1500"  # Optional: override UID:GID (default is 1000:1000)
     devices:
       - /dev/dri:/dev/dri
     group_add:

--- a/examples/04-hwaccel-cuda/README.md
+++ b/examples/04-hwaccel-cuda/README.md
@@ -35,6 +35,21 @@ It uses the NVIDIA CUDA base image and includes FFmpeg with NVENC support.
 - **GPU Access**: Configured via `runtime: nvidia` and environment variables.
 - **Groups**: Container user added to host `video` group for GPU access.
 
+## Custom UID/GID
+
+If your media library uses different ownership, set the `user` field in
+docker-compose.yml. Note the CUDA variant defaults to UID **1001** (not 1000):
+
+```yaml
+user: "1001:1500"
+```
+
+Then chown your volumes to match:
+
+```bash
+sudo chown -R 1001:1500 ./seanime-config
+```
+
 ## Important
 
 - This variant is **amd64 only** (x86_64).

--- a/examples/04-hwaccel-cuda/docker-compose.yml
+++ b/examples/04-hwaccel-cuda/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   seanime:
     image: umagistr/seanime:latest-cuda
     container_name: seanime
+    # user: "1001:1500"  # Optional: override UID:GID (default is 1001:1001)
     # Option 1: Using runtime (recommended)
     runtime: nvidia
     group_add:

--- a/specifications/container-cuda.md
+++ b/specifications/container-cuda.md
@@ -140,6 +140,24 @@ deploy:
   - `all` - All capabilities (recommended)
   - `compute,video,utility` - Specific capabilities
 
+### Custom UID/GID
+
+To run as a different UID:GID than the default 1001:1001, use Docker's native
+`user` option:
+
+```yaml
+# docker-compose.yml
+user: "1001:1500"
+```
+
+```bash
+# docker run
+docker run --user 1001:1500 ...
+```
+
+Pre-chown volumes to match: `sudo chown -R 1001:1500 ./seanime-config`.
+The config path remains `/home/seanime/.config/Seanime` regardless of UID.
+
 ### Entrypoint/Command
 
 - **USER**: `1001`

--- a/specifications/container-default.md
+++ b/specifications/container-default.md
@@ -95,6 +95,11 @@ Default mount points (from examples):
 
 None required for basic operation.
 
+### Custom UID/GID
+
+The default variant runs as root. For custom UID:GID support, use the
+rootless, hwaccel, or CUDA variants with Docker's `user:` option instead.
+
 ### Entrypoint/Command
 
 - **CMD**: `["/app/seanime"]`

--- a/specifications/container-hwaccel.md
+++ b/specifications/container-hwaccel.md
@@ -125,6 +125,26 @@ Default mount points (from examples):
 
 None required for basic operation.
 
+### Custom UID/GID
+
+To run as a different UID:GID than the default 1000:1000, use Docker's native
+`user` option:
+
+```yaml
+# docker-compose.yml
+user: "1000:1500"
+```
+
+```bash
+# docker run
+docker run --user 1000:1500 ...
+```
+
+Pre-chown volumes to match: `sudo chown -R 1000:1500 ./seanime-config`.
+The config path remains `/home/seanime/.config/Seanime` regardless of UID.
+The `group_add` directive for `video` and `render` groups continues to work
+alongside `user:` — it uses host group IDs.
+
 ### Entrypoint/Command
 
 - **USER**: `1000`

--- a/specifications/container-rootless.md
+++ b/specifications/container-rootless.md
@@ -106,6 +106,24 @@ Default mount points (from examples):
 
 None required for basic operation.
 
+### Custom UID/GID
+
+To run as a different UID:GID than the default 1000:1000, use Docker's native
+`user` option:
+
+```yaml
+# docker-compose.yml
+user: "1000:1500"
+```
+
+```bash
+# docker run
+docker run --user 1000:1500 ...
+```
+
+Pre-chown volumes to match: `sudo chown -R 1000:1500 ./seanime-config`.
+The config path remains `/home/seanime/.config/Seanime` regardless of UID.
+
 ### Entrypoint/Command
 
 - **USER**: `1000`


### PR DESCRIPTION
## Summary

- Document Docker's native `user:` (compose) and `--user` (CLI) flags for custom UID:GID support
- Addresses user request for PUID/PGID-like functionality without code changes
- Verified working: `--user 1000:1500` with `latest-rootless` starts seanime, serves HTTP 200, healthcheck passes

## Changes

- **README.md**: New "Custom User/Group ID" section with compose + CLI examples, LSIO comparison note
- **3 docker-compose examples**: Commented `user:` field (rootless, hwaccel, CUDA)
- **3 example READMEs**: Custom UID/GID instructions with variant-specific defaults
- **4 specification files**: Custom UID/GID sections for all container variants

## Context

User requested PUID/PGID env var support (LinuxServer.io convention). After investigating the LSIO pattern (entrypoint + su-exec/gosu + usermod), we discovered Docker's native `user:` flag already solves this with zero code changes, no security model change, and no new dependencies. This follows the same approach Jellyfin adopted when they deprecated their PUID/PGID support.

## Test plan

- [x] Verified `docker run --user 1000:1500 umagistr/seanime:latest-rootless id` → `uid=1000 gid=1500`
- [x] Verified `docker run --user 1234:5678 umagistr/seanime:latest-rootless id` → `uid=1234 gid=5678`
- [x] Verified container starts, serves HTTP 200, healthcheck reports `healthy`
- [ ] Verify hwaccel variant with `user:` + `group_add` for GPU access (needs hardware)
- [ ] Verify CUDA variant with `user:` override (needs NVIDIA GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)